### PR TITLE
Fix receiver organisations

### DIFF
--- a/iatidatacube/import_data.py
+++ b/iatidatacube/import_data.py
@@ -177,7 +177,7 @@ def map_budget_transaction_csv_row_to_db_dict(row, codelists, reporting_organisa
     il['provider_organisation_id'] = make_organisations_hash(
         dict([(f'provider_org#{lang}', row[f'provider_org#{lang}']) for lang in langs]))
     il['receiver_organisation_id'] = make_organisations_hash(
-        dict([(f'provider_org#{lang}', row[f'receiver_org#{lang}']) for lang in langs]))
+        dict([(f'receiver_org#{lang}', row[f'receiver_org#{lang}']) for lang in langs]))
     return il
 
 

--- a/models/iatiline.json
+++ b/models/iatiline.json
@@ -325,7 +325,7 @@
             "key_attribute": "id",
             "label_attribute": "name_en",
             "label": "Provider Organisation",
-            "join_column": "receiver_organisation_id"
+            "join_column": "provider_organisation_id"
         },
         "provider_organisation_type": {
             "attributes": {


### PR DESCRIPTION
Receiver organisations are currently displaying in both the provider and receiver organisation columns. This PR ensures that they are displayed correctly. Only the change in the `models/iatiline.json` is actually required.

However, I also corrected a typo in `iatidatacube/import_data.py`, because it is confusing (though only the dict values are actually used, so it doesn't actually make a difference).

Fixes #18