### PR TITLE
Fix rollups calendar year and quarter

### DIFF
--- a/iatidatacube/app.py
+++ b/iatidatacube/app.py
@@ -46,6 +46,9 @@ def register_responses(app):
     def handle_xlsx(response):
         if request.args.get('format') == 'xlsx':
             response_json = response.get_json(force=True)
+            if len(response_json.get('cells', []) + response_json.get('data', [])) == 0:
+                response = make_response(jsonify(msg="There are no results mathing your selection."), 404)
+                return response
             if 'cells' in response_json:
                 data = list(xlsx_writer.serialise(request.args, response_json['cells']))
             else:

--- a/iatidatacube/app.py
+++ b/iatidatacube/app.py
@@ -47,7 +47,7 @@ def register_responses(app):
         if request.args.get('format') == 'xlsx':
             response_json = response.get_json(force=True)
             if len(response_json.get('cells', []) + response_json.get('data', [])) == 0:
-                response = make_response(jsonify(msg="There are no results mathing your selection."), 404)
+                response = make_response(jsonify(msg="There are no results matching your selection."), 404)
                 return response
             if 'cells' in response_json:
                 data = list(xlsx_writer.serialise(request.args, response_json['cells']))

--- a/iatidatacube/xlsx_writer.py
+++ b/iatidatacube/xlsx_writer.py
@@ -29,9 +29,20 @@ def serialise(args, data):
             _r_dimension, _r_attribute = rollup.split('.')
         else:
             _r_dimension = rollup
-        get_rollup_values_from_db = babbage.get_cube('iatiline').members(_r_dimension)
-        rollup_values_from_db = dict([(t[f'{_r_dimension}.code'],
-            t[f'{_r_dimension}.name_{lang}']) for t in get_rollup_values_from_db['data']])
+        get_rollup_values_from_db = babbage.get_cube('iatiline').members(_r_dimension,
+            page_size=100000)
+        # Some rollups do not have language-specific labels,
+        # e.g. years, quarters, multi-country
+        if (f'{_r_dimension}.code' in get_rollup_values_from_db['fields']) and \
+            (f'{_r_dimension}.name_{lang}' in get_rollup_values_from_db['fields']):
+            key = f'{_r_dimension}.code'
+            label = f'{_r_dimension}.name_{lang}'
+        else:
+            # Get the first field that matches this dimension
+            key = get_rollup_values_from_db['fields'][0]
+            label = get_rollup_values_from_db['fields'][0]
+        rollup_values_from_db = dict([(t[key],
+            t[label]) for t in get_rollup_values_from_db['data']])
 
     for row in data:
         _l = {}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -153,3 +153,12 @@ class TestAPI:
             aggregates='value_usd.sum',
             format='xlsx', lang='en'))
         assert res.status_code == 200
+
+
+    def test_get_empty_xlsx(self, import_transactions, client):
+        res = client.get(url_for('babbage_api.aggregate', name='iatiline',
+            drilldown='recipient_country_or_region',
+            cut='transaction_type.code:"3";"4"|calendar_year_and_quarter:"9999 Q1"',
+            aggregates='value_usd.sum',
+            format='xlsx', lang='en'))
+        assert res.status_code == 404

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -133,3 +133,23 @@ class TestAPI:
         'Value (USD) (2013 Q1)', 'Value (USD) (2013 Q2)']
         assert xlsx_as_csv[0]['Value (USD) (2013 Q1)'] == 1984341
         assert xlsx_as_csv[0]['Value (USD) (2013 Q2)'] == 595716
+
+
+    @pytest.mark.parametrize("rollup_name,rollup_values", [
+        ("sector_category.code", ["120","150","160","310","430"]),
+        ("sector.code", ["12220","15170","16010","31120","43040"]),
+        ("year.year", ["2007","2008","2009","2010","2011","2012","2013","2014","2015"]),
+        ("quarter.quarter", ["Q1","Q2","Q3","Q4"]),
+        ("calendar_year_and_quarter", ["2013 Q1","2013 Q2","2013 Q3","2013 Q4"]),
+        ])
+    def test_get_drilldowns_rollups_various(self, import_transactions, client, rollup_name, rollup_values):
+        rollup_values_cuts = ";".join([f'"{v}"' for v in rollup_values])
+        rollup_values_rollups = ",".join([f'["{v}"]' for v in rollup_values])
+
+        res = client.get(url_for('babbage_api.aggregate', name='iatiline',
+            drilldown='recipient_country_or_region',
+            cut=f'transaction_type.code:"3";"4"|{rollup_name}:{rollup_values_cuts}',
+            rollup=f'{rollup_name}:[{rollup_values_rollups}]',
+            aggregates='value_usd.sum',
+            format='xlsx', lang='en'))
+        assert res.status_code == 200

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -119,3 +119,17 @@ class TestAPI:
         assert xlsx_as_csv[0]['Value (USD) (Décaissement, Dépenses)'] == 58742699
         assert xlsx_as_csv[0]['Value (USD) (Budget)'] == 58000000
 
+
+    def test_get_drilldowns_rollups_xlsx_quarters(self, import_transactions, client):
+        res = client.get(url_for('babbage_api.aggregate', name='iatiline',
+            drilldown='recipient_country_or_region',
+            cut='transaction_type.code:"3";"4"|calendar_year_and_quarter:"2013 Q1";"2013 Q2"',
+            rollup='calendar_year_and_quarter:[["2013 Q1"],["2013 Q2"]]',
+            aggregates='value_usd.sum',
+            format='xlsx', lang='en'))
+        xlsx_res = res.get_data()
+        xlsx_as_csv = xlsx_to_csv.get_data(xlsx_res, xlsx_res, 'Data')
+        assert list(xlsx_as_csv[0].keys()) == ['Recipient Country or Region',
+        'Value (USD) (2013 Q1)', 'Value (USD) (2013 Q2)']
+        assert xlsx_as_csv[0]['Value (USD) (2013 Q1)'] == 1984341
+        assert xlsx_as_csv[0]['Value (USD) (2013 Q2)'] == 595716


### PR DESCRIPTION
* Fixes a couple of bugs where calendar years and quarters cannot be used as rollups
* Fixes a small bug where an empty result set creates an error 500 for Excel files